### PR TITLE
Pin ex_aws version to 2.0 instead of 2.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule ExAws.ECS.Mixfile do
   defp ex_aws() do
     case System.get_env("AWS") do
       "LOCAL" -> {:ex_aws, path: "../ex_aws"}
-      _ -> {:ex_aws, "~> 2.0.0"}
+      _ -> {:ex_aws, "~> 2.0"}
     end
   end
 


### PR DESCRIPTION
## Context
`ex_aws_ecs` pins the `ex_aws` version to `2.0.0` - requiring an dependants using a minor version of v2 (i.e. `2.1.0`) to downgrade.

There don't seem to be any compatibility issues with `2.0` vs `2.x` with this library.

## Summary of Changes
- Pin the `ex_aws` version to `2.0` instead of `2.0.0`